### PR TITLE
feat: add an async query parameter to wait for page data's

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ You can customize the pdf setting by using those query parms:
 * `margin.left`: the left marging,
 * `margin.bottom`: the bottom margin,
 * `margin.right`: the right margin,
+* `async`: set to true to wait page data's
 
 They're discribed on the [Puppeteer API doc](https://github.com/GoogleChrome/puppeteer/blob/v1.12.2/docs/api.md#pagepdfoptions)


### PR DESCRIPTION
This change allows adding an asynchronous query parameter to wait until `networkidle0` before creating the PDF. 
`networkidle0` is a Puppeteer parameter that is call when there is no network request while 500ms. 

Example : https://url-to-pdf.acrabadabra.com/?async=true&url=https://google.fr